### PR TITLE
Add getAppsFlyerUID to react native api

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,10 @@ af.init(appId, devKey, function(err, events) {
     af.sendTrackingWithEvent(eventName, {key1: value1, key2: value2}, function(err, events) {
         //events is {key1: value1, key2, value2}
     });
+
+    //To get appsFlyerUID an event,
+    af.getAppsFlyerUID(function(err, uid) {
+
+    });
 })
 ```

--- a/ios/RNAppsFlyer.m
+++ b/ios/RNAppsFlyer.m
@@ -27,5 +27,10 @@ RCT_EXPORT_METHOD(sendTrackingWithEvent: (NSString *)eventName eventValues:(NSDi
   callback(@[[NSNull null], eventValues]);
 }
 
+RCT_EXPORT_METHOD(getAppsFlyerUID: (RCTResponseSenderBlock)callback)
+{
+    NSString *uid = [[AppsFlyerTracker sharedTracker] getAppsFlyerUID];
+    callback(@[[NSNull null], uid]);
+}
+
 @end
-  


### PR DESCRIPTION
I've added a bridge method to allow the appsFlyer.getAppsFlyerUID method to be called from react native
