### PR TITLE
Changed include dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,21 @@ This React Natie Library uses the AppsFlyer 4.6.0 library for both iOS and Andro
 1. import `import com.ppsreejith.RNAppsFlyerPackage;`
 2. In the `getPackages()` method register the module `new RNAppsFlyerPackage(MainApplication.this)`
 
-##### build.gradle
-1. Add the project to your dependencies `compile project(':react-native-apps-flyer')`
+##### android/app/build.gradle
+1. Add the project to your dependencies
+```gradle
+dependencies {
+    ...
+    compile project(':react-native-apps-flyer')
+}
+```
 
-##### settings.gradle
+##### android/settings.gradle
 1. Add the project
-`include ':react-native-apps-flyer`
-`project(':react-native-apps-flyer').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-apps-flyer/android')`
+```gradle
+include ':react-native-apps-flyer'
+project(':react-native-apps-flyer').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-apps-flyer/android')
+```
 
 ## Usage
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.33.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.appsflyer:af-android-sdk:4.6.0'
     compile 'com.google.android.gms:play-services-ads:9.6.1'
     compile 'com.google.android.gms:play-services-identity:9.6.1'

--- a/package.json
+++ b/package.json
@@ -57,9 +57,6 @@
   ],
   "name": "react-native-apps-flyer",
   "optionalDependencies": {},
-  "peerDependencies": {
-    "react-native": "^0.28.0"
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
I've got warning when installed plugin to latest version of react native.

`npm WARN react-native-apps-flyer@1.2.4 requires a peer of react-native@^0.28.0 but none was installed.`

Also fixed https://github.com/ppsreejith/react-native-apps-flyer/issues/10
